### PR TITLE
avoid throwing on undefined children property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function assignParents(modules) {
   var result = {};
   Object.keys(modules).forEach(function (moduleName) {
     const parent = modules[moduleName];
-    const line = parent.children;
+    const line = parent.children || [];
     line.forEach(({id: childName}) => {
       result[childName] = result[childName] || {parents: []};
       result[childName].parents.push(moduleName)


### PR DESCRIPTION
This fixes an issue with modules that modify the cache but might not include the children property.